### PR TITLE
added support to single char in dayNamesShort

### DIFF
--- a/src/datePicker/components/Calendar.js
+++ b/src/datePicker/components/Calendar.js
@@ -21,8 +21,8 @@ const Calendar = () => {
     <View style={style.container}>
       <Header changeMonth={changeMonthAnimation} />
       <View style={[style.daysName, utils.flexDirection]}>
-        {utils.config.dayNamesShort.map(item => (
-          <Text key={item} style={style.daysNameText}>
+        {utils.config.dayNamesShort.map((item, index) => (
+          <Text key={index} style={style.daysNameText}>
             {item}
           </Text>
         ))}


### PR DESCRIPTION
In portuguese days of the week are as 

- Domingo
- Segunda-feira
- Terça-feira
- Quarta-feira
- Quinta-feira
- Sexta-feira
- Sábado

So when we use just one single char to show short names of the days, react return an error about keys